### PR TITLE
FIX Change required JS file case

### DIFF
--- a/code/ResponsiveImageHTMLEditorField_Toolbar.php
+++ b/code/ResponsiveImageHTMLEditorField_Toolbar.php
@@ -70,7 +70,7 @@ class ResponsiveImageHtmlEditorField_Toolbar extends Extension{
 	}
 
 	public function updatemediaform($form){
-		Requirements::javascript(RESPONSIVE_WYSIWYG_IMAGES_DIR . '/javascript/HTMLEditorField.js');
+		Requirements::javascript(RESPONSIVE_WYSIWYG_IMAGES_DIR . '/javascript/HtmlEditorField.js');
 	}
 
 


### PR DESCRIPTION
Please be careful with case sensitivity, as this issue wasted a significant amount of my time.

Although the plugin worked perfectly on my Windows file system based dev environment, it inexplicably failed on the live *nix based environment. Eventually I was able to pinpoint the issue to the fact you were including 'HTMLEditorField.js' while the filename is actually 'HtmlEditorField.js'.

It seems @nyeholt located this same issue earlier in the year on his fork, so I'd suggest merging it into master, to prevent anyone else suffering the same fate that I did.
